### PR TITLE
WIP for fixing #20

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,8 +6,16 @@ Changelog
 1.2.2 (unreleased)
 ------------------
 
-- Add .editorconfig File to maintain code convetions following Plone API
-- Add Support for Python 3
+New:
+
+  - Add .editorconfig File to maintain code conventions following Plone API
+  - Add Support for Python 3
+  - Basic test support (via ./bin/py setup.py test)
+
+Fix:
+
+  - handle extends in parent folder (initial work to fix #20)
+    [ale-rt]
 
 
 1.2.1 (2016-01-26)

--- a/README.rst
+++ b/README.rst
@@ -278,8 +278,15 @@ Clone the project. Then::
 
     $ bootstrap.sh
 
+Tests
+-----
+
+Given you have launched `bootstrap.sh` as suggested,
+you can run the tests with::
+
+    $ ./bin/py setup.py test
+
 License
 =======
 
 The project is licensed under the GPLv2.
-

--- a/setup.py
+++ b/setup.py
@@ -18,9 +18,9 @@ setup(
     # Get more strings from
     # http://pypi.python.org/pypi?:action=list_classifiers
     classifiers=[
-      'Framework :: Buildout',
-      'Programming Language :: Python',
-      'Programming Language :: Python :: 2.7',
+        'Framework :: Buildout',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2.7',
     ],
     keywords='plone buildout version ',
     author='Jens W. Klein',
@@ -51,4 +51,5 @@ setup(
             'default = plone.versioncheck.tracking:install',
         ]
     },
+    test_suite='plone.versioncheck.tests',
 )

--- a/src/plone/versioncheck/tests/__init__.py
+++ b/src/plone/versioncheck/tests/__init__.py
@@ -1,0 +1,1 @@
+# coding=utf-8

--- a/src/plone/versioncheck/tests/test_utils.py
+++ b/src/plone/versioncheck/tests/test_utils.py
@@ -1,0 +1,24 @@
+# coding=utf-8
+from plone.versioncheck.utils import find_relative
+from unittest import TestCase
+
+
+class TestUtils(TestCase):
+
+    def test_find_relative(self):
+        ''' Checks if find relative is working nicely
+        '''
+        self.assertEqual(
+            find_relative('http://example.com/foo.cfg'),
+            'http://example.com'
+        )
+        self.assertEqual(
+            find_relative('file://../versions/foo.cfg'),
+            'file://../versions',
+        )
+        # BBB: this test should fail!
+        self.assertEqual(
+            find_relative('../versions/foo.cfg'),
+            '',
+            # BBB: it should be equal to ../versions
+        )

--- a/src/plone/versioncheck/utils.py
+++ b/src/plone/versioncheck/utils.py
@@ -88,11 +88,18 @@ def requests_session(nocache=False):
 
 
 def find_relative(extend):
+    ''' takes an extend line and parses it.
+
+    Returns the directory containing the file
+    '''
+    if extend.startswith('../'):
+        # BBB fix me!
+        return ''
     if "://" in extend:
         parts = list(urlparse(extend))
-        parts[2] = '/'.join(parts[2].split('/')[:-1])
+        parts[2] = parts[2].rpartition('/')[0]
         return urlunparse(parts)
-    elif '/' in extend:
+    if '/' in extend:
         return os.path.dirname(extend)
 
 ###########################################################


### PR DESCRIPTION
This will indeed close #20, but with an ugly hack :/
Now I am too tired/lazy too go on and properly fix things :)
Just wanted to share the fix.

What I do not like is the fact that the find_relative function is unaware of the:
- current working directory
- of the path (or url) of the cfg file containing the extend.

I think that to gathere all the extends it would be better to use something more structured of a simple function, because, as happening in this case, you can have bad surprises.

Probably this code can be a good starting point:
- https://github.com/RedTurtle/rt.ploneversions/blob/master/rt/ploneversions/ploneversions.py
  but it expects all the extends to be "urlopenable" objects.

I know that even @mauritsvanrees has [something similar](https://gist.github.com/mauritsvanrees/1097587) (and for sure better) in is pocket!

As a side note, the PR adds some unit tests.
I wanted to increase the coverage, maybe another day!
