### PR TITLE
Fix an IndexError: string index out of range error with empty states …

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 1.5.2 (unreleased)
 ------------------
 
+- Fix an ``IndexError: string index out of range`` error with empty states in the formatter.
+  [thet]
+
 - Added basic tests to package.
   [loechel]
 

--- a/src/plone/versioncheck/formatter.py
+++ b/src/plone/versioncheck/formatter.py
@@ -202,7 +202,8 @@ def human(
                 version['version'] +
                 dots(version['version'], pkgsinfo['ver_maxlen']) +
                 ' ' + color_by_state(version['state']) +
-                version['state'][0] + ' ' + version['description']
+                version['state'][0] if version['state'] else '' +
+                ' ' + version['description']
             )
             if version.get('annotation', None):
                 indent = (pkgsinfo['ver_maxlen'] + 5) * ' ' + 'a '


### PR DESCRIPTION
…in the formatter.

the version dict was showing in the error case for ``html5lib``:
```
(Pdb) version
{'state': '', 'version': '(annotation)', 'description': 'https://raw.githubusercontent.com/plone/buildout.coredev/5.1/versions.cfg', 'annotation': u'Double version numbers: 0.9999 == 1.0b5, 0.99999 == 1.0b6, etcetera.\n0.99999999/1.0b9 changes too much and cannot be used with current bleach (1.4/1.5), which is used by zest.releaser.\nbleach 1.4.3 and higher have an explicit restriction, and this can only handle the version number with nines, not the 1.0bX.'}
```