### PR TITLE
add functionality to get release date from PyPI

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,9 @@ Changelog
 - Added basic tests to package.
   [loechel]
 
+- Add function to extract date information from PyPI to analyze package age.
+  [loechel]
+
 1.5.1 (2017-01-23)
 ------------------
 

--- a/bar.cfg
+++ b/bar.cfg
@@ -1,4 +1,4 @@
 [buildout]
 
 [versions]
-Products.CMFCore = 2.0
+Products.CMFCore = 2.2.0

--- a/baz.cfg
+++ b/baz.cfg
@@ -1,4 +1,4 @@
 [buildout]
 
 [versions]
-Products.CMFCore = 3.1
+Products.CMFCore = 2.2.10

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -26,7 +26,7 @@ interpreter = py
 ipython = 4.0.2
 
 # this is for self check only
-Products.CMFCore = 3.0.3
+Products.CMFCore = 2.1.1
 lazy = 1.0
 
 [code-analysis]

--- a/foo.cfg
+++ b/foo.cfg
@@ -3,5 +3,5 @@ extends =
     baz.cfg
 
 [versions]
-Products.CMFCore = 3.0.1
+Products.CMFCore = 2.3.0
 collective.quickupload = 1.5.8

--- a/src/plone/versioncheck/formatter.py
+++ b/src/plone/versioncheck/formatter.py
@@ -10,6 +10,7 @@ from plone.versioncheck.utils import color_init
 from plone.versioncheck.utils import dots
 from plone.versioncheck.utils import get_terminal_size
 
+import datetime
 import json
 import sys
 import textwrap
@@ -50,7 +51,8 @@ def build_version(
         else:
             record['state'] = 'I'
     else:  # pypi
-        record['version'] = pypi[key]
+        record['version'] = pypi[key].version
+        record['release_date'] = pypi[key].release_date
         record['description'] = key.capitalize()
         record['annotation'] = None
         if 'pre' in key:
@@ -231,6 +233,15 @@ def human(
             )
 
 
+def json_serial(obj):
+    """JSON serializer for objects not serializable by default json code"""
+
+    if isinstance(obj, datetime.date):
+        serial = obj.isoformat()
+        return serial
+    raise TypeError('Type not serializable')
+
+
 def browser(
     pkgsinfo,
     newer_only=False,
@@ -263,4 +274,4 @@ def machine(
         newer_orphaned_only=newer_orphaned_only,
         limit=limit
     )
-    print(json.dumps(data, indent=4))
+    print(json.dumps(data, indent=4, default=json_serial))

--- a/src/plone/versioncheck/tpl/browser.jinja
+++ b/src/plone/versioncheck/tpl/browser.jinja
@@ -57,6 +57,7 @@
         <tr>
           <th>package</th>
           <th>version</th>
+          <th>release date</th>
           <th>state</th>
           <th>info</th>
           <th>annotation</th>
@@ -74,6 +75,7 @@
             {% endif %}
 
             <td class="color-{{version['state']}}">{{version['version']}}</td>
+            <td class="color-{{version['state']}}">{{version['release_date']}}</td>
             <td class="color-{{version['state']}}">{{version['state'][0]}}</td>
             <td class="color-{{version['state']}}">{{version['description']}}</td>
             <td class="color-{{version['state']}}">{% if version['annotation'] %}{{version['annotation']}}<br />{% else %}&nbsp;{% endif %}</td>


### PR DESCRIPTION
We do have some extremely outdated packages, we should be able to find them quicker, this adds functionality to get release date from PyPI and outputs that in machine and browser output.