### PR TITLE
Fix return statement

### DIFF
--- a/src/plone/versioncheck/parser.py
+++ b/src/plone/versioncheck/parser.py
@@ -127,7 +127,7 @@ def _extract_versions_section(  # NOQA: C901
     try:
         extends = config.get('buildout', 'extends').strip()
     except (NoSectionError, NoOptionError):
-        return version_sections
+        return version_sections, annotations
     for extend in reversed(extends.splitlines()):
         extend = extend.strip()
         if not extend:


### PR DESCRIPTION
If a file does not extend any other file, the return statement was returning only one parameter, while callers expected 2.