### PR TITLE
Catch empty version and ignore invalid versions in more places.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,9 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Catch empty version and ignore invalid versions in more places.
+  Needed when a package is explicitly unpinned, for example ``Zope =``.
+  [maurits]
 
 
 1.8.0 (2023-04-15)

--- a/src/plone/versioncheck/pypi.py
+++ b/src/plone/versioncheck/pypi.py
@@ -42,10 +42,16 @@ def check(name, version, session):  # noqa: C901
         ]
     )
 
+    if not version:
+        return False, "Empty version."
+
     # parse version to test against:
     try:
         version = parse_version(version)
-    except TypeError:
+    except Exception:
+        # likely pkg_resources.extern.packaging.version.InvalidVersion
+        # or TypeError, but really any exception can be ignored.
+        # See https://github.com/plone/plone.versioncheck/issues/52
         return False, "Version broken/ not checkable."
     try:
         vtuple = mmbp_tuple(version)


### PR DESCRIPTION
Needed when a package is explicitly unpinned, for example `Zope =`. See failed coredev job after I checked out Zope and use its versions config files: https://github.com/plone/buildout.coredev/actions/runs/4859777432/jobs/8662807731